### PR TITLE
Player jumping in water when on recover didnt return to checkpoint

### DIFF
--- a/Erlang-Legacy/Assets/Core/Combat/Hazard/DeadlyObject.cs
+++ b/Erlang-Legacy/Assets/Core/Combat/Hazard/DeadlyObject.cs
@@ -37,13 +37,11 @@ namespace Core.Hazard
         private IEnumerator ResetSavePoint()
         {
             PlayerController player = PlayerController.Instance;
-            bool playerSurvives = player.PlayerData.Health.HP - damage > 0;
-
             player.Hurt(damage, gameObject);
 
             yield return new WaitForSeconds(cWaitTime);
 
-            if (playerSurvives)
+            if (player.IsAlive())
                 player.transform.position = GameSessionController.Instance.currentSavePos;
 
             playerIn = false;

--- a/Erlang-Legacy/Assets/Core/GameSession/GameSessionController.cs
+++ b/Erlang-Legacy/Assets/Core/GameSession/GameSessionController.cs
@@ -16,7 +16,8 @@ namespace Core.GameSession
         public Vector3 currentSavePos { get; private set; }
         private EntranceID entranceTag;
         private bool inDieProcess = false;
-        public bool LoadData {
+        public bool LoadData
+        {
             get => loadData;
             set
             {
@@ -67,10 +68,15 @@ namespace Core.GameSession
 
             inDieProcess = false;
 
-            if (entranceTag != EntranceID.None)
-                SearchEntrance();
-            else
+            if (loadData) //player has died 
+            {
+                LoadSavedData();
                 PlacePlayer();
+            }
+            else if (entranceTag != EntranceID.None) //player came from other scene
+            {
+                SearchEntrance();
+            }
 
             SetUpPlayerLifes();
         }
@@ -83,7 +89,7 @@ namespace Core.GameSession
                 return;
 
             var playerCurrentHealth = PlayerController.Instance.PlayerData.Health.HP;
-            if (!inDieProcess & playerCurrentHealth == 0)
+            if (!inDieProcess & playerCurrentHealth <= 0)
             {
                 inDieProcess = true;
                 ResetGameToLastSave();
@@ -122,7 +128,11 @@ namespace Core.GameSession
             PlayerController.Instance.OnDie();
 
             FindObjectOfType<InGameCanvas>()?.ActiveDeathImage();
-            StartCoroutine(Loader.LoadWithDelay((SceneID)LoadSavedData(), 5f));
+
+            loadData = true;
+
+            PlayerState playerState = SaveSystem.LoadPlayerState();
+            StartCoroutine(Loader.LoadWithDelay((SceneID)playerState.scene, 5f));
         }
 
         //pre: entranceTag != entranceID.None

--- a/Erlang-Legacy/Assets/Core/Player/Controller/PlayerController.cs
+++ b/Erlang-Legacy/Assets/Core/Player/Controller/PlayerController.cs
@@ -114,7 +114,7 @@ namespace Core.Player.Controller
         // post: applies damage to player. 1 unit of damage represent 1 unit of life taken
         public void Hurt(int damage, GameObject other)
         {
-            if (protectable.IsProtected)
+            if (protectable.IsProtected || !IsAlive())
                 return;
 
             FreezeMovement();
@@ -190,6 +190,7 @@ namespace Core.Player.Controller
         public void OnDie()
         {
             controllable = false;
+            FreezeMovement();
             Animator.SetTrigger(CharacterAnimations.Die);
         }
 


### PR DESCRIPTION
Player now can fall in water or lava when it's on recover and be displayed on check point.

Also fix problems from last PR...
IsAlive methor worked incorrectly because lifes were updated on GameSessionController before the new scene was loaded.

closes #145 